### PR TITLE
make it useful (from my point of view)

### DIFF
--- a/cmds/request/wow/achievement.js
+++ b/cmds/request/wow/achievement.js
@@ -5,17 +5,10 @@ const logger = require('../../../lib/logger');
 
 const request = yargs
   .command({
-    command: 'achievement',
+    command: 'achievement <id>',
     describe: 'Fetch a World of Warcraft achievement',
     builder: yargs => {
       return yargs
-        .options({
-          id: {
-            alias: 'i',
-            describe: 'The [id] of the {achievement}',
-            demand: true,
-          },
-        });
     },
     handler: argv => logger('wow', 'achievement', argv),
   }).argv;

--- a/cmds/request/wow/character.js
+++ b/cmds/request/wow/character.js
@@ -5,23 +5,11 @@ const logger = require('../../../lib/logger');
 
 const character = yargs
   .command({
-    command: 'character',
+    command: 'character <origin> <realm> <name>',
     describe: 'Fetch a World of Warcraft character',
     builder: yargs => {
       return yargs
         .options({
-          realm: {
-            alias: 'r',
-            describe: 'The [realm] of the {character}',
-            type: 'string',
-            demand: true,
-          },
-          name: {
-            alias: 'n',
-            describe: 'The [name] of the {character}',
-            type: 'string',
-            demand: true,
-          },
           fields: {
             alias: 'f',
             describe: 'A list of one or more [fields] belonging to the {character}',

--- a/cmds/request/wow/guild.js
+++ b/cmds/request/wow/guild.js
@@ -5,23 +5,11 @@ const logger = require('../../../lib/logger');
 
 const guild = yargs
   .command({
-    command: 'guild',
+    command: 'guild <origin> <realm> <name>',
     describe: 'Fetch a World of Warcraft guild',
     builder: yargs => {
       return yargs
         .options({
-          realm: {
-            alias: 'r',
-            describe: 'The [realm] of the {guild}',
-            type: 'string',
-            demand: true,
-          },
-          name: {
-            alias: 'n',
-            describe: 'The name of the guild',
-            type: 'string',
-            demand: true,
-          },
           fields: {
             alias: 'f',
             describe: 'A list of one or more [fields] belonging to the {guild}',

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -7,6 +7,10 @@ const db = require('./db');
 
 module.exports = (command, resource, obj) => {
   const args = argv[command](resource, obj);
+  function display (request) {
+    console.log(request.response);
+  }
+
 
   return db.models.RecentRequest.findOne({
     where: { command, resource, args: JSON.stringify(args) },
@@ -17,7 +21,7 @@ module.exports = (command, resource, obj) => {
   })
   .then(request => {
     if (request) {
-      return console.log(request.get()); // TODO log with winston.info
+      return display(request);
     }
 
     async.waterfall([
@@ -42,7 +46,8 @@ module.exports = (command, resource, obj) => {
         return console.log(err); // TODO log with winston.error
       }
 
-      return console.log(result.get()); // TODO log with winston.info
+      return display(result.get());
+      // return console.log(result.get()); // TODO log with winston.info
     });
   })
   .catch(err => {


### PR DESCRIPTION
I needed a tool for  my requests outside, my own librairie and I didn't want to loose too much time on this, since i want a tool to loose less time going to the official dev.battle.net, that may not fit your need and i only modified what I needed right now.

# Requests
first I want something quick to type and conform to what most unix tool seems to do.
using flags for choosing entry point for querying an object is fine, the object is the same on us or on eu. when you request for a character, origin / realm name / character name cannot be optional so they have to be verbs not flags.

so the whole command line for asking my own character become
```
td  request wow character eu archimonde Sweetlie
```

I don't know what's the use for "request" verb but as I have an alias on `td request wow` it doesn't bother me.


# Output
There's a lot that can be done on this field, beautiful json color highlight, but as I love unix a default to raw body is what I need the most
then I can post process with jq

```
td  request wow character eu archimonde Sweetlie | jq
```
This will print me a nice json structure with highlight

or better
```
request wow guild eu tarren-mill Method -f members | jq ".members[] | .character .name" | head -n

"Buffsplease"
"Thug"
"Gosmeister"
"Xiripstwo"
"Påhmil"
```

I don't want to break anything, and this is more a fix for my personal need and a suggestion of what can be done than a pull request.

